### PR TITLE
Fix/RI crawler tasks 1

### DIFF
--- a/Coding Dojo - Crawler.ipynb
+++ b/Coding Dojo - Crawler.ipynb
@@ -346,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 8 - Efetuar a requisição - método `request_url`:** Neste método você irá fazer a requisição usando a api [requests](https://requests.readthedocs.io/en/master/). Além disso, deve-se informar no cabeçalho (em `User-Agent`) o nome do coletor. O método deverá retornar o conteúdo (em binário) apenas se o conteúdo for HTML (ver no cabeçalho da resposta o tipo do conteúdo). Caso não seja, ele deverá retornar nulo. "
+    "**Atividade 8 - Efetuar a requisição - método `request_url`:** Neste método você irá fazer a requisição usando a api [requests](https://requests.readthedocs.io/en/master/). Além disso, deve-se informar no cabeçalho (em `User-Agent`) o nome do coletor. O método deverá retornar o conteúdo (em binário) apenas se o conteúdo for HTML (ver no cabeçalho da resposta o tipo do conteúdo). Caso não seja, ele deverá retornar `None`. "
    ]
   },
   {
@@ -429,7 +429,6 @@
     "Baeza-Yates, Ricardo; Ribeiro-Neto, Berthier. **Modern information retrieval: the concepts and technology behind search**. ACM Press, 2011.\n",
     "\n",
     "Batista, Natércia ; Brandão, Michele ; Pinheiro, Michele ; Dalip, Daniel ; Moro, Mirella . **[Dados de Múltiplas Fontes da Web: coleta, integração e pré-processamento](https://sol.sbc.org.br/livros/index.php/sbc/catalog/download/8/19/58-1?inline=1)**. Minicursos do XXIV Simpósio Brasileiro de Sistemas Multimídia e Web. 1ed.: Sociedade Brasileira de Computação, 2018, v. , p. 153-192."
-
    ]
   }
  ],

--- a/crawler/scheduler.py
+++ b/crawler/scheduler.py
@@ -2,6 +2,7 @@ from urllib import robotparser
 from urllib.parse import ParseResult
 
 from util.threads import synchronized
+from time import sleep
 from collections import OrderedDict
 from .domain import Domain
 

--- a/crawler/scheduler_test.py
+++ b/crawler/scheduler_test.py
@@ -52,7 +52,7 @@ class SchedulerTest(unittest.TestCase):
                                    depth_limit=self.DEPTH_LIMIT,
                                    arr_urls_seeds=arr_urls_seeds)
         
-        self.assertEqual(3, self.scheduler.page_count, "Nao foi adicionado as sementes solicitadas")
+        self.assertEqual(len(arr_str_urls_seeds), self.scheduler.page_count, "Nao foi adicionado as sementes solicitadas")
 
     def test_can_add_page(self):
         self.__testCanAddPageWithLongTimeLimit()

--- a/crawler/scheduler_test.py
+++ b/crawler/scheduler_test.py
@@ -145,7 +145,7 @@ class SchedulerTest(unittest.TestCase):
         self.assertTrue(not bol_not_allowed,
                         f"Não deveria ser permitida requisitar a url {obj_url_not_allowed.geturl()} segundo o robots.txt  do dominio {obj_url_not_allowed.netloc}, porém o método can_fetch_page retornou True")
         self.assertTrue(bol_allowed,
-                        f"Não deveria ser permitida requisitar a url {obj_url_allowed.geturl()} segundo o robots.txt do dominio {obj_url_allowed.netloc}, porém o método can_fetch_page retornou False")
+                        f"Deveria ser permitida requisitar a url {obj_url_allowed.geturl()} segundo o robots.txt do dominio {obj_url_allowed.netloc}, porém o método can_fetch_page retornou False")
 
         # verifica se foi adicionado a globo.com
         self.assertTrue(obj_url_allowed.netloc in self.scheduler.dic_robots_per_domain,

--- a/crawler/scheduler_test.py
+++ b/crawler/scheduler_test.py
@@ -46,7 +46,13 @@ class SchedulerTest(unittest.TestCase):
         arr_str_urls_seeds = ["cnn.com",
                               "www.gq.com.au/", "www.huffingtonpost.com/"]
         arr_urls_seeds = [urlparse(str_url) for str_url in arr_str_urls_seeds]
-        self.assertEqual(3, 3, "Nao foi adicionado as sementes solicitadas")
+        
+        self.scheduler = Scheduler(usr_agent="xxbot",
+                                   page_limit=self.TIME_LIMIT,
+                                   depth_limit=self.DEPTH_LIMIT,
+                                   arr_urls_seeds=arr_urls_seeds)
+        
+        self.assertEqual(3, self.scheduler.page_count, "Nao foi adicionado as sementes solicitadas")
 
     def test_can_add_page(self):
         self.__testCanAddPageWithLongTimeLimit()

--- a/crawler/scheduler_test.py
+++ b/crawler/scheduler_test.py
@@ -24,13 +24,13 @@ class DomainTest(unittest.TestCase):
 
 
 class SchedulerTest(unittest.TestCase):
-    urlXpto = (urlparse("http://www.xpto.com.br/index.html"), 100000)
-    urlTerra = (urlparse("http://www.terra.com.br/index.html"), 1)
-    urlTerra2 = (urlparse("http://www.terra.com.br/index.html"), 1)
-    urlTerraRep = (urlparse("http://www.terra.com.br/index.html"), 1)
-    urlUOL1 = (urlparse("http://www.uol.com.br/"), 1)
-    urlUOL2 = (urlparse("http://www.uol.com.br/profMax.html"), 1)
-    urlGlobo = (urlparse("http://www.globo.com.br/profMax.html"), 1)
+    urlXpto = (urlparse("https://www.xpto.com.br/index.html"), 100000)
+    urlTerra = (urlparse("https://www.terra.com.br/index.html"), 1)
+    urlTerra2 = (urlparse("https://www.terra.com.br/index.html"), 1)
+    urlTerraRep = (urlparse("https://www.terra.com.br/index.html"), 1)
+    urlUOL1 = (urlparse("https://www.uol.com.br/"), 1)
+    urlUOL2 = (urlparse("https://www.uol.com.br/profMax.html"), 1)
+    urlGlobo = (urlparse("https://www.globo.com.br/profMax.html"), 1)
     MOCK_USER_AGENT = 'azulaoBot'
     TIME_LIMIT = 10
     DEPTH_LIMIT = 3

--- a/crawler/scheduler_test.py
+++ b/crawler/scheduler_test.py
@@ -37,9 +37,9 @@ class SchedulerTest(unittest.TestCase):
     SEEDS = []
 
     def setUp(self):
-        self.scheduler = Scheduler(str_usr_agent="xxbot",
-                                   int_page_limit=self.TIME_LIMIT,
-                                   int_depth_limit=self.DEPTH_LIMIT,
+        self.scheduler = Scheduler(usr_agent="xxbot",
+                                   page_limit=self.TIME_LIMIT,
+                                   depth_limit=self.DEPTH_LIMIT,
                                    arr_urls_seeds=self.SEEDS)
 
     def test_init(self):
@@ -58,9 +58,9 @@ class SchedulerTest(unittest.TestCase):
             self.assertFalse(canAddXpto, msg='A url XPTO não deveria poder ser adicionada')
 
     def __test_existed_domain(self):
-        scheduler_test = Scheduler(str_usr_agent=self.MOCK_USER_AGENT,
-                                   int_page_limit=self.TIME_LIMIT,
-                                   int_depth_limit=self.DEPTH_LIMIT,
+        scheduler_test = Scheduler(usr_agent=self.MOCK_USER_AGENT,
+                                   page_limit=self.TIME_LIMIT,
+                                   depth_limit=self.DEPTH_LIMIT,
                                    arr_urls_seeds=self.SEEDS)
         self.__test_can_add_uol1(scheduler_test)
         self.__add_uol_1(scheduler_test)


### PR DESCRIPTION
## Correções de problema nos testes

- Corrigido nome dos parâmetros posicionais do construtor de Sheduler
- Corrigido referência http que estava gerando erro no certificado ssl ao redirecionar
- Corrigido erro de digitação no teste do Allow "Não deveria"
- Corrigido teste "test_init" que não fazia nada, agora ele verifica devidamente se o construtor está funcionando

## Melhoria no texto do notebook

- Ajustado testo ambíguo "nulo" que agora especifica None

## Melhoria no código

- O padrão do projeto é já vir com os imports necessários, mas o import do sleep não estava no arquivo