### PR TITLE
add install of dependency lxml

### DIFF
--- a/Coding Dojo - Crawler.ipynb
+++ b/Coding Dojo - Crawler.ipynb
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Se necessário, instale o python3 e o pip3 abaixo usando `sudo apt-get install python3 python3-pip`.  Execute abaixo para instalar o [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/). Qualquer linha de comando/código como a de baixo, você pode executá-la a selecionando e pressionando `ctrl+enter` ❣️."
+    "Se necessário, instale o python3 e o pip3 abaixo usando `sudo apt-get install python3 python3-pip`.  Execute abaixo para instalar o [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/) e o [lxml](https://lxml.de/). Qualquer linha de comando/código como a de baixo, você pode executá-la a selecionando e pressionando `ctrl+enter` ❣️."
    ]
   },
   {
@@ -54,7 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install bs4"
+    "!pip3 install bs4\n",
+    "!pip3 install lxml"
    ]
   },
   {


### PR DESCRIPTION
Ao tentar utilizar o BeautifulSoup na minha máquina, eu recebi o seguinte erro:

_bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?_

Isso ocorreu porque, no meu sistema, o lxml não veio instalado por padrão. Diante disso, sugiro a inclusão do comando 
`pip3 install lxml` para a instalação dessa dependência, caso outros alunos também já não a possuam em suas máquinas. 