### PR TITLE
fix test of discoverLinks (page_fetcher)

### DIFF
--- a/crawler/page_fetcher_test.py
+++ b/crawler/page_fetcher_test.py
@@ -29,7 +29,7 @@ class PageFetcherTest(unittest.TestCase):
                               <a href='xxi/lala.html'></a>\
                              <a href='http://www.terra.com.br/oi/lala.html'></a>"
 
-        arr_expected_links = [(urlparse('http://www.pudim.com.br/lala.html'), 3),
+        arr_expected_links = [(urlparse('https://www.pudim.com.br/lala.html'), 3),
                               (urlparse('http://www.pudim.com.br/xxi/lala.html'), 3),
                               (urlparse('http://www.terra.com.br/oi/lala.html'), 0)
                               ]

--- a/crawler/page_fetcher_test.py
+++ b/crawler/page_fetcher_test.py
@@ -34,7 +34,11 @@ class PageFetcherTest(unittest.TestCase):
                               (urlparse('http://www.terra.com.br/oi/lala.html'), 0)
                               ]
         print(f"Simulação da extração de links da página {obj_url.geturl()} na profundidade nível 2...")
-        for i,(url_link,depth) in enumerate(self.fetcher.discover_links(obj_url,2,bin_str_content)):
+        
+        discovered_links = self.fetcher.discover_links(obj_url,2,bin_str_content)
+        self.assertEqual(len(arr_expected_links), len(list(discovered_links)),f"A quantidade de links descobertos deveria ser {len(arr_expected_links)} e não {len(list(discovered_links))}")
+
+        for i,(url_link,depth) in enumerate(discovered_links):
             self.assertEqual(arr_expected_links[i][0].geturl(),url_link.geturl(),f"A {i + 1}ª URL extraída seria {arr_expected_links[i][0].geturl()} e não {url_link.geturl()}")
             self.assertEqual(arr_expected_links[i][1],depth,f"A profundiade da URL {arr_expected_links[i][0].geturl()} seria {arr_expected_links[i][1]} e não {depth}")
 

--- a/crawler/page_fetcher_test.py
+++ b/crawler/page_fetcher_test.py
@@ -33,10 +33,11 @@ class PageFetcherTest(unittest.TestCase):
                               (urlparse('http://www.pudim.com.br/xxi/lala.html'), 3),
                               (urlparse('http://www.terra.com.br/oi/lala.html'), 0)
                               ]
+
         print(f"Simulação da extração de links da página {obj_url.geturl()} na profundidade nível 2...")
         
-        discovered_links = self.fetcher.discover_links(obj_url,2,bin_str_content)
-        self.assertEqual(len(arr_expected_links), len(list(discovered_links)),f"A quantidade de links descobertos deveria ser {len(arr_expected_links)} e não {len(list(discovered_links))}")
+        discovered_links = list(self.fetcher.discover_links(obj_url,2,bin_str_content))
+        self.assertEqual(len(arr_expected_links), len(discovered_links),f"A quantidade de links descobertos deveria ser {len(arr_expected_links)} e não {len(discovered_links)}")
 
         for i,(url_link,depth) in enumerate(discovered_links):
             self.assertEqual(arr_expected_links[i][0].geturl(),url_link.geturl(),f"A {i + 1}ª URL extraída seria {arr_expected_links[i][0].geturl()} e não {url_link.geturl()}")


### PR DESCRIPTION
Ao executar o teste unitário da atividade 9 (método discover_links), eu fui surpreendido com um sucesso do teste, mesmo sem ter feito nada no método sendo testado. Isso aconteceu porque o teste percorre o retorno do método discover_links e, para cada elemento, fazia as verificações. Entretanto, caso o método não retorne nada (que foi o meu caso, já que eu ainda não o havia implementado), as verificações nunca ocorrem, já que ele nunca entra no loop. Para corrigir isso, foi adicionada uma verificação de tamanho do retorno do método, para garantir que a quantidade de links descobertos seja igual à quantidade esperada de links descobertos. Assim, mesmo que o método não retorne nada e não entre no loop das verificações, o teste irá falhar, por conta da diferença na quantidade de links descobertos. 