### PR TITLE
fix scheduler method has_finished_crawl

### DIFF
--- a/crawler/scheduler.py
+++ b/crawler/scheduler.py
@@ -44,9 +44,7 @@ class Scheduler:
         """
         :return: True se finalizou a coleta. False caso contrário.
         """
-        if self.page_count > self.page_limit:
-            return True
-        return False
+        return self.page_count >= self.page_limit
 
     @synchronized
     def can_add_page(self, obj_url: ParseResult, depth: int) -> bool:


### PR DESCRIPTION
A forma como a comparação era feita no método fazia com que fosse coletada uma página a mais do que o limite:
```
if self.page_count > self.page_limit:
      return True
```
Como self.page_count é o número de páginas JÁ COLETADAS, o coletor sempre coletaria uma página a mais do que o limite. Para corrigir isso, basta substituir o > por >=. Além disso, não há necessidade do if, basta retornar o resultado booleano da comparação:
` return self.page_count >= self.page_limit`

